### PR TITLE
Remove dead CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Providing Better Compilation Performance Information
 
-[![Build
-Status](https://platform-ci.scala-lang.org/api/badges/scalacenter/scalac-profiling/status.svg)](https://platform-ci.scala-lang.org/scalacenter/scalac-profiling)
-
 When compile times become a problem, how can Scala developers reason about
 the relation between their code and compile times?
 


### PR DESCRIPTION
we could have a GitHub Actions badge instead, I guess, but I think such badges are basically noise