### PR TITLE
Remove `println` in sbt-plugin

### DIFF
--- a/sbt-plugin/src/main/scala/sbt/ch/epfl/scala/SbtTaskTimer.scala
+++ b/sbt-plugin/src/main/scala/sbt/ch/epfl/scala/SbtTaskTimer.scala
@@ -56,10 +56,7 @@ class SbtTaskTimer(timers: ConcurrentHashMap[ScopedKey[_], BoxedLong], isDebugEn
     }
 
     getKey(task) match {
-      case Some(key) => {
-        println(key)
-      finishTiming(key)
-      }
+      case Some(key) => finishTiming(key)
       case None => () // Ignore tasks that do not have key information
     }
 


### PR DESCRIPTION
I'm seeing a lot of spammy `println`s in `1.1.0-RC1` like:
```
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,legacy-api)), Select(ConfigKey(compile)), Zero, Zero),exportedProducts)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),internalDependencyClasspath)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),dependencyClasspath)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),dependencyVirtualClasspath)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),dependencyPicklePath)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileIncSetup)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Select(compile), Zero),compileOptions)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),previousCompile)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Select(compile), Zero),compileInputs)
[info] compiling 349 Scala sources and 16 Java sources to /Users/lorenzo/codacy/github/codacy-website/app/target/scala-2.13/classes ...
[info] Writing graph to /Users/lorenzo/codacy/github/codacy-website/app/target/scala-2.13/classes/META-INF/profiledb/graphs/implicit-searches-1698594885712.flamegraph
[info] Creating global statistics information at /Users/lorenzo/codacy/github/codacy-website/app/target/scala-2.13/classes/META-INF/profiledb/global.profiledb.
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileIncremental)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileScalaBackend)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileSplit)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),manipulateBytecode)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),manipulateBytecode)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compile)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compile)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Zero, Zero, Zero),compile)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),discoveredMainClasses)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileOutputs)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Zero, Zero),compileOutputs)
ScopedKey(Scope(Select(ProjectRef(file:/Users/lorenzo/codacy/github/codacy-website/,app)), Select(ConfigKey(compile)), Select(compileOutputs), Zero),dynamicFileOutputs)
```

This PR removes them.