### PR TITLE
Emit the warning if the `-Vstatistics` option isn't set

### DIFF
--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -296,7 +296,7 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
           super.run()
 
           if (!SettingsOps.areStatisticsEnabled(global)) {
-            val flagName = global.settings.Ystatistics.name.replace("-V", "-Y")
+            val flagName = global.settings.Ystatistics.name
             global.runReporting.warning(
               NoPosition,
               s"`${self.name}` compiler plugin requires the option `$flagName` to be enabled",

--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -56,13 +56,13 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
   }
 
   private final lazy val config = PluginConfig(
-    super.options.contains(ShowProfiles),
-    super.options.contains(NoProfileDb),
-    findOption(SourceRoot, SourceRootRegex).map(AbsolutePath.apply),
-    findSearchIds(findOption(PrintSearchResult, PrintSearchRegex)),
-    super.options.contains(GenerateMacroFlamegraph),
-    super.options.contains(PrintFailedMacroImplicits),
-    super.options.contains(ShowConcreteImplicitTparams)
+    showProfiles = super.options.contains(ShowProfiles),
+    noDb = super.options.contains(NoProfileDb),
+    sourceRoot = findOption(SourceRoot, SourceRootRegex).map(AbsolutePath.apply),
+    printSearchIds = findSearchIds(findOption(PrintSearchResult, PrintSearchRegex)),
+    generateMacroFlamegraph = super.options.contains(GenerateMacroFlamegraph),
+    printFailedMacroImplicits = super.options.contains(PrintFailedMacroImplicits),
+    concreteTypeParamsInImplicits = super.options.contains(ShowConcreteImplicitTparams)
   )
 
   private lazy val logger = new Logger(global)


### PR DESCRIPTION
Resolves #45.
The following warning will be emitted if the `Ystatistics` option isn't set:
```
[warn] `scalac-profiling` compiler plugin requires the option `-Ystatistics` to be enabled
```
By enabling the `-Xfatal-warnings` option, it will be an error:
```
[error] `scalac-profiling` compiler plugin requires the option `-Ystatistics` to be enabled
```

It's convenient to manage fatal behaviour with `-Xfatal-warnings`, but the output contains excessive debug information, causing that warning may go unnoticed. 
**UPD**: if users don't enable the `-P:scalac-profiling:show-profiles` option, the output is much consier.
WDYT @lolgab @sjrd @SethTisue?