### PR TITLE
Add functionality to build a global flamegraph of implicit searches

### DIFF
--- a/plugin/src/main/scala-2.12/ch/epfl/scala/profilers/tools/ScalaSettingsOps.scala
+++ b/plugin/src/main/scala-2.12/ch/epfl/scala/profilers/tools/ScalaSettingsOps.scala
@@ -1,0 +1,6 @@
+package ch.epfl.scala.profilers.tools
+
+object ScalaSettingsOps {
+  def isScala212: Boolean = true
+  def isScala213: Boolean = false
+}

--- a/plugin/src/main/scala-2.13/ch/epfl/scala/profilers/tools/ScalaSettingsOps.scala
+++ b/plugin/src/main/scala-2.13/ch/epfl/scala/profilers/tools/ScalaSettingsOps.scala
@@ -1,0 +1,6 @@
+package ch.epfl.scala.profilers.tools
+
+object ScalaSettingsOps {
+  def isScala212: Boolean = false
+  def isScala213: Boolean = true
+}

--- a/plugin/src/main/scala/ch/epfl/scala/PluginConfig.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/PluginConfig.scala
@@ -2,12 +2,13 @@ package ch.epfl.scala
 
 import ch.epfl.scala.profiledb.utils.AbsolutePath
 
-case class PluginConfig(
+final case class PluginConfig(
     showProfiles: Boolean,
     noDb: Boolean,
-    sourceRoot: Option[AbsolutePath],
+    sourceRoot: AbsolutePath,
     printSearchIds: Set[Int],
     generateMacroFlamegraph: Boolean,
+    generateGlobalFlamegraph: Boolean,
     printFailedMacroImplicits: Boolean,
     concreteTypeParamsInImplicits: Boolean
 )

--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -71,8 +71,11 @@ class ProfilingPlugin(val global: Global) extends Plugin {
   private lazy val logger = new Logger(global)
 
   private def pad20(option: String): String = option + (" " * (20 - option.length))
+
   override def init(ops: List[String], e: (String) => Unit): Boolean = true
+
   override val optionsHelp: Option[String] = Some(s"""
+       |-P:$name:${pad20(GenerateGlobalFlamegraph)}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
        |-P:$name:${pad20(SourceRoot)}:_ Sets the source root for this project.
        |-P:$name:${pad20(ShowProfiles)} Logs profile information for every call-site.
        |-P:$name:${pad20(ShowConcreteImplicitTparams)} Shows types in flamegraphs of implicits with concrete type params.

--- a/profiledb/src/main/scala/ch.epfl.scala.profiledb/ProfileDbPath.scala
+++ b/profiledb/src/main/scala/ch.epfl.scala.profiledb/ProfileDbPath.scala
@@ -35,6 +35,9 @@ object ProfileDbPath {
   def toProfileDbPath(relativeSourceFile: RelativePath): RelativePath =
     Prefix.resolveRelative(addDbExtension(relativeSourceFile))
 
+  def toGraphsProfilePath(path: AbsolutePath): AbsolutePath =
+    path.resolve(GraphsProfileDbRelativePath)
+
   private[profiledb] def addDbExtension(path: RelativePath): RelativePath = {
     val realPath = path.underlying
     val extendedName = realPath.getFileName.toString + ProfileDbExtension


### PR DESCRIPTION
Resolves #43

This PR brings the `-P:scalac-profiling:generate-global-flamegraph` plugin option that enables building the global flamegraph of implicit searches for all compilation units. In fact, these graphs are built us assembling the flamegraphs of all compilation units. The Flamegraph tool accumulates all repetitive tokens on its own in the resulting graph.