### PR TITLE
Invert the `no-profiledb` option into `generate-profiledb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ All the compiler plugin options are **prepended by `-P:scalac-profiling:`**.
   flamegraph for implicit searches is enabled by default.
 * `print-failed-implicit-macro-candidates`: Print trees of all failed implicit
   searches that triggered a macro expansion.
-* `no-profiledb`: Recommended. Don't generate profiledb (will be on by default
-  in a future release).
+* `generate-profiledb`: Generate profiledb.
 * `show-concrete-implicit-tparams`: Use more concrete type parameters in the
   implicit search flamegraph. Note that it may change the shape of the
   flamegraph.

--- a/plugin/src/main/scala/ch/epfl/scala/PluginConfig.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/PluginConfig.scala
@@ -4,7 +4,7 @@ import ch.epfl.scala.profiledb.utils.AbsolutePath
 
 case class PluginConfig(
     showProfiles: Boolean,
-    noDb: Boolean,
+    generateDb: Boolean,
     sourceRoot: Option[AbsolutePath],
     printSearchIds: Set[Int],
     generateMacroFlamegraph: Boolean,

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -181,9 +181,8 @@ object BuildImplementation {
         val projectBuild = ref.build
         val workingDir = Keys.buildStructure.value.units(projectBuild).localBase.getAbsolutePath
         val sourceRoot = s"-P:scalac-profiling:sourceroot:$workingDir"
-        val noProfileDb = s"-P:scalac-profiling:no-profiledb"
         val pluginOpts = (PluginProject / BuildKeys.optionsForSourceCompilerPlugin).value
-        noProfileDb +: sourceRoot +: pluginOpts
+        sourceRoot +: pluginOpts
       }
     }
 


### PR DESCRIPTION
Resolves #26 

After using `scalac-profiling` for a while, I totally agree that it's a reasonable default behaviour to disable the generation of profiledb.