### PR TITLE
Detouch `vscode-scala`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "vscode-scala"]
-	path = vscode-scala
-	url = git@github.com:scalacenter/vscode-scala-profiledb.git
-	branch = profiledb-integration
 [submodule "FlameGraph"]
 	path = FlameGraph
 	url = git@github.com:jvican/FlameGraph.git

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -11,8 +11,3 @@ align.openParenDefnSite = false
 binPack.literalArgumentLists = true
 project.git = true
 trailingCommas = preserve
-
-# exclude submodules
-project.excludeFilters = [
-  "vscode-scala/"
-]

--- a/build.sbt
+++ b/build.sbt
@@ -115,41 +115,6 @@ lazy val plugin = project
     assembly / test := {}
   )
 
-// Trick to copy profiledb with Scala 2.11.11 so that vscode can depend on it
-// lazy val profiledb211 = profiledb
-//   .copy(id = "profiledb-211")
-//   .settings(
-//     moduleName := "profiledb",
-//     scalaVersion := (scalaVersion in VscodeImplementation).value,
-//     // Redefining target so that sbt doesn't clash at runtime
-//     // This makes sense, but we should get a more sensible error message.
-//     target := (baseDirectory in profiledb).value./("target_211")
-//   )
-
-// This is the task to publish the vscode integration
-// val publishExtension = taskKey[Unit]("The task to publish the vscode extension.")
-
-// Has to be in independent project because uses different Scala version
-// lazy val vscodeIntegration = project
-//   .in(file(".hidden"))
-//   .dependsOn(VscodeImplementation, profiledb211)
-//   .settings(
-//     scalaVersion := (scalaVersion in VscodeImplementation).value,
-//     libraryDependencies in VscodeImplementation += (projectID in profiledb211).value,
-//     // Sbt bug: doing this for VscodeImplementation just doesn't work.
-//     update := update.dependsOn(publishLocal in profiledb211).value,
-//     publish := (publish in VscodeImplementation).dependsOn(publish in profiledb211).value,
-//     publishLocal :=
-//       (publishLocal in VscodeImplementation).dependsOn(publishLocal in profiledb211).value,
-//     publishExtension := (Def
-//       .task {
-//         val scalaExtensionDir = (baseDirectory in VscodeScala).value./("scala")
-//         sys.process.Process(Seq("vsce", "package"), scalaExtensionDir).!!
-//       })
-//       .dependsOn(publishLocal)
-//       .value
-//   )
-//
 lazy val profilingSbtPlugin = project
   .in(file("sbt-plugin"))
   .settings(

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -40,9 +40,6 @@ object BuildKeys {
   final val AbsolutePath = file(".").getCanonicalFile.getAbsolutePath
   final val HomeBuild = BuildRef(RootProject(file(AbsolutePath)).build)
 
-  // final val VscodeScala = RootProject(file(s"$AbsolutePath/vscode-scala"))
-  // final val VscodeImplementation = ProjectRef(VscodeScala.build, "ensime-lsp")
-
   // Source dependencies from git are cached by sbt
   val BetterFiles = RootProject(
     uri(


### PR DESCRIPTION
[`vscode-scala`](https://github.com/dragos/dragos-vscode-scala) has been archived.
```This repository has been archived by the owner on Jun 8, 2023.```
If we implement integration with vscode one day, it will be done via Metals.