### PR TITLE
Enhance `optionsHelp` of the compiler plugin

### DIFF
--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -80,6 +80,7 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
         GenerateGlobalFlamegraph
       )}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
        |-P:$name:${pad20(SourceRoot)}:_ Sets the source root for this project.
+       |-P:$name:${pad20(GenerateProfileDb)}:_ Sets the source root for this project.
        |-P:$name:${pad20(ShowProfiles)} Logs profile information for every call-site.
        |-P:$name:${pad20(
         ShowConcreteImplicitTparams
@@ -87,6 +88,12 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
        |-P:$name:${pad20(
         PrintSearchResult
       )}:_ Print implicit search result trees for a list of search ids separated by a comma.
+       |-P:$name:${pad20(
+        GenerateMacroFlamegraph
+      )} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
+       |-P:$name:${pad20(
+        PrintFailedMacroImplicits
+      )} Prints trees of all failed implicit searches that triggered a macro expansion.
     """.stripMargin
   )
 

--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -79,21 +79,21 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
        |-P:$name:${pad20(
         GenerateGlobalFlamegraph
       )}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
-       |-P:$name:${pad20(SourceRoot)}:_ Sets the source root for this project.
-       |-P:$name:${pad20(GenerateProfileDb)}:_ Sets the source root for this project.
-       |-P:$name:${pad20(ShowProfiles)} Logs profile information for every call-site.
        |-P:$name:${pad20(
-        ShowConcreteImplicitTparams
-      )} Shows types in flamegraphs of implicits with concrete type params.
+        GenerateMacroFlamegraph
+      )} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
+       |-P:$name:${pad20(GenerateProfileDb)}:_ Sets the source root for this project.
+       |-P:$name:${pad20(
+        PrintFailedMacroImplicits
+      )} Prints trees of all failed implicit searches that triggered a macro expansion.
        |-P:$name:${pad20(
         PrintSearchResult
       )}:_ Print implicit search result trees for a list of search ids separated by a comma.
        |-P:$name:${pad20(
-        GenerateMacroFlamegraph
-      )} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
-       |-P:$name:${pad20(
-        PrintFailedMacroImplicits
-      )} Prints trees of all failed implicit searches that triggered a macro expansion.
+        ShowConcreteImplicitTparams
+      )} Shows types in flamegraphs of implicits with concrete type params.
+       |-P:$name:${pad20(ShowProfiles)} Logs profile information for every call-site.
+       |-P:$name:${pad20(SourceRoot)}:_ Sets the source root for this project.
     """.stripMargin
   )
 

--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -77,9 +77,9 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
   // format: off
   override val optionsHelp: Option[String] = Some(
     s"""
-       |-P:$name:${pad20(GenerateGlobalFlamegraph)}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
+       |-P:$name:${pad20(GenerateGlobalFlamegraph)} Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
        |-P:$name:${pad20(GenerateMacroFlamegraph)} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
-       |-P:$name:${pad20(GenerateProfileDb)}:_ Sets the source root for this project.
+       |-P:$name:${pad20(GenerateProfileDb)} Generates profiledb (will be removed later).
        |-P:$name:${pad20(PrintFailedMacroImplicits)} Prints trees of all failed implicit searches that triggered a macro expansion.
        |-P:$name:${pad20(PrintSearchResult)}:_ Print implicit search result trees for a list of search ids separated by a comma.
        |-P:$name:${pad20(ShowConcreteImplicitTparams)} Shows types in flamegraphs of implicits with concrete type params.

--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -74,28 +74,19 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
 
   override def init(ops: List[String], e: (String) => Unit): Boolean = true
 
+  // format: off
   override val optionsHelp: Option[String] = Some(
     s"""
-       |-P:$name:${pad20(
-        GenerateGlobalFlamegraph
-      )}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
-       |-P:$name:${pad20(
-        GenerateMacroFlamegraph
-      )} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
+       |-P:$name:${pad20(GenerateGlobalFlamegraph)}: Creates a global flamegraph of implicit searches for all compilation units. Use the `-P:$name:$SourceRoot` option to manage the root directory, otherwise, a working directory (defined by the `user.dir` property) will be picked.
+       |-P:$name:${pad20(GenerateMacroFlamegraph)} Generates a flamegraph for macro expansions. The flamegraph for implicit searches is enabled by default.
        |-P:$name:${pad20(GenerateProfileDb)}:_ Sets the source root for this project.
-       |-P:$name:${pad20(
-        PrintFailedMacroImplicits
-      )} Prints trees of all failed implicit searches that triggered a macro expansion.
-       |-P:$name:${pad20(
-        PrintSearchResult
-      )}:_ Print implicit search result trees for a list of search ids separated by a comma.
-       |-P:$name:${pad20(
-        ShowConcreteImplicitTparams
-      )} Shows types in flamegraphs of implicits with concrete type params.
+       |-P:$name:${pad20(PrintFailedMacroImplicits)} Prints trees of all failed implicit searches that triggered a macro expansion.
+       |-P:$name:${pad20(PrintSearchResult)}:_ Print implicit search result trees for a list of search ids separated by a comma.
+       |-P:$name:${pad20(ShowConcreteImplicitTparams)} Shows types in flamegraphs of implicits with concrete type params.
        |-P:$name:${pad20(ShowProfiles)} Logs profile information for every call-site.
        |-P:$name:${pad20(SourceRoot)}:_ Sets the source root for this project.
     """.stripMargin
-  )
+  ) // format: on
 
   lazy val implementation = new ProfilingImpl(ProfilingPlugin.this.global, config, logger)
   implementation.registerProfilers()


### PR DESCRIPTION
Some of the existing compiler plugin options were missing in `optionsHelp`. 