### PR TITLE
Remove sbt 0.13 artefacts in sbt-plugin

### DIFF
--- a/sbt-plugin/src/main/scala-sbt-0.13/sbt/ch/epfl/scala/Compat.scala
+++ b/sbt-plugin/src/main/scala-sbt-0.13/sbt/ch/epfl/scala/Compat.scala
@@ -1,5 +1,0 @@
-package sbt.ch.epfl.scala
-
-object Compat {
-  type ExecCommand = String
-}

--- a/sbt-plugin/src/main/scala-sbt-1.0/sbt/ch/epfl/scala/Compat.scala
+++ b/sbt-plugin/src/main/scala-sbt-1.0/sbt/ch/epfl/scala/Compat.scala
@@ -1,7 +1,0 @@
-package sbt.ch.epfl.scala
-
-object Compat {
-  type ExecCommand = sbt.Exec
-  implicit def command2String(command: ExecCommand) = command.commandLine
-  implicit def string2Exex(s: String): ExecCommand = sbt.Exec(s, None, None)
-}

--- a/sbt-plugin/src/main/scala/sbt/ch/epfl/scala/ProfilingSbtPlugin.scala
+++ b/sbt-plugin/src/main/scala/sbt/ch/epfl/scala/ProfilingSbtPlugin.scala
@@ -63,13 +63,12 @@ object ProfilingPluginImplementation {
     import sbt.{Command, State}
     import sbt.complete.Parser
 
-    import sbt.ch.epfl.scala.Compat._
     val profilingWarmupCompiler: Def.Initialize[Task[Unit]] = Def.task {
       // Meh, we don't care about the resulting state, we'll throw it away.
-      def runCommandAndRemaining(command: ExecCommand): State => State = { st: State =>
+      def runCommandAndRemaining(command: sbt.Exec): State => State = { st: State =>
         @annotation.tailrec
-        def runCommand(command: ExecCommand, state: State): State = {
-          val nextState = Parser.parse(command, state.combinedParser) match {
+        def runCommand(command: sbt.Exec, state: State): State = {
+          val nextState = Parser.parse(command.commandLine, state.combinedParser) match {
             case Right(cmd) => cmd()
             case Left(msg) => sys.error(s"Invalid programmatic input:\n$msg")
           }
@@ -90,7 +89,7 @@ object ProfilingPluginImplementation {
 
       // This is ugly, but the Command sbt API is constrained in this regard.
       val commandName = profilingWarmupCommand.asInstanceOf[sbt.SimpleCommand].name
-      runCommandAndRemaining(commandName)(tweakedState)
+      runCommandAndRemaining(sbt.Exec(commandName, None, None))(tweakedState)
       ()
     }
 


### PR DESCRIPTION
As of `1.1.0-RC1`, support for sbt 0.13 has been purged.