### PR TITLE
Add the --skip-image-compression option to docusaurus-build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
-    "build": "docusaurus-build",
+    "build": "docusaurus-build --skip-image-compression=true",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",


### PR DESCRIPTION
An attempt to resolve #79