### PR TITLE
Fix typo in passing options to docusaurus-build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
-    "build": "docusaurus-build --skip-image-compression=true",
+    "build": "docusaurus-build --skip-image-compression",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",


### PR DESCRIPTION
At the local machine, this doesn't change anything and compression was disabled, but this doesn't seem to fix the issue with the actual compression in the `gh-pages` branch 🤔 