### PR TITLE
Add a Github Action for pruning caches in CI

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,53 @@
+# all credits to the sbt/sbt-github-actions projects
+name: Clean
+
+on: push
+
+jobs:
+  delete-artifacts:
+    name: Delete Artifacts
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Delete artifacts
+        run: |
+          # Customize those three lines with your repository and credentials:
+          REPO=${GITHUB_API_URL}/repos/${{ github.repository }}
+
+          # A shortcut to call GitHub API.
+          ghapi() { curl --silent --location --user _:$GITHUB_TOKEN "$@"; }
+
+          # A temporary file which receives HTTP response headers.
+          TMPFILE=/tmp/tmp.$$
+
+          # An associative array, key: artifact name, value: number of artifacts of that name.
+          declare -A ARTCOUNT
+
+          # Process all artifacts on this repository, loop on returned "pages".
+          URL=$REPO/actions/artifacts
+          while [[ -n "$URL" ]]; do
+
+            # Get current page, get response headers in a temporary file.
+            JSON=$(ghapi --dump-header $TMPFILE "$URL")
+
+            # Get URL of next page. Will be empty if we are at the last page.
+            URL=$(grep '^Link:' "$TMPFILE" | tr ',' '\n' | grep 'rel="next"' | head -1 | sed -e 's/.*<//' -e 's/>.*//')
+            rm -f $TMPFILE
+
+            # Number of artifacts on this page:
+            COUNT=$(( $(jq <<<$JSON -r '.artifacts | length') ))
+
+            # Loop on all artifacts on this page.
+            for ((i=0; $i < $COUNT; i++)); do
+
+              # Get name of artifact and count instances of this name.
+              name=$(jq <<<$JSON -r ".artifacts[$i].name?")
+              ARTCOUNT[$name]=$(( $(( ${ARTCOUNT[$name]} )) + 1))
+
+              id=$(jq <<<$JSON -r ".artifacts[$i].id?")
+              size=$(( $(jq <<<$JSON -r ".artifacts[$i].size_in_bytes?") ))
+              printf "Deleting '%s' #%d, %'d bytes\n" $name ${ARTCOUNT[$name]} $size
+              ghapi -X DELETE $REPO/actions/artifacts/$id
+            done
+          done

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,4 +1,4 @@
-# all credits to the sbt/sbt-github-actions projects
+# all credits to the sbt/sbt-github-actions project
 name: Clean
 
 on: push


### PR DESCRIPTION
We are already approaching the total cache storage limit (8.97 GB of 10 GB Used). 
Kudos to the `sbt/sbt-github-actions` project for this GA.