### PR TITLE
Fix accounting of macro expansion times and expanded nodes for the `show-profiles` flag

### DIFF
--- a/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/ProfilingPlugin.scala
@@ -265,7 +265,7 @@ class ProfilingPlugin(val global: Global) extends Plugin { self =>
         val currentPos = Some(toPos(pos))
         val expandedMacros = info.expandedMacros.toLong
         val approximateSize = info.expandedNodes.toLong
-        val duration = Some(toDuration(info.expansionNanos))
+        val duration = Some(toDuration(info.expansionTime.toNanos))
         schema.MacroProfile(
           position = currentPos,
           expandedMacros = expandedMacros,

--- a/plugin/src/main/scala/ch/epfl/scala/profilers/ProfilingImpl.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/profilers/ProfilingImpl.scala
@@ -95,7 +95,12 @@ final class ProfilingImpl[G <: Global](
       .map(v => v.original -> v.count)
       .toMap*/
 
-    MacroProfiler(perCallSite, perFile, inTotal, Map.empty)
+    val callSiteMicros = perCallSite.map {
+      case (k, v) =>
+        k -> v.copy(expansionTime = FiniteDuration(v.expansionTime.toMicros, TimeUnit.MICROSECONDS))
+    }
+
+    MacroProfiler(callSiteMicros, perFile, inTotal, Map.empty)
   }
 
   case class ImplicitInfo(count: Int) {

--- a/plugin/src/main/scala/ch/epfl/scala/profilers/ProfilingImpl.scala
+++ b/plugin/src/main/scala/ch/epfl/scala/profilers/ProfilingImpl.scala
@@ -67,9 +67,6 @@ final class ProfilingImpl[G <: Global](
       repeatedExpansions: Map[Tree, Int]
   )
 
-  def toMillis(nanos: Long): Long =
-    java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(nanos)
-
   def groupPerFile[V](
       kvs: Map[Position, V]
   )(empty: V, aggregate: (V, V) => V): Map[SourceFile, V] = {


### PR DESCRIPTION
Fixes #97 

This PR rectifies filling in the data by adjusting the current approach, so I'm not 100% confident about the resulting data's accuracy. At the very least, it seems meaningful. After applying these changes, the output when leveraging the `show-profiles` flag looks like this:
```
[info]   RangePosition(/scala-steward/modules/core/src/main/scala/org/scalasteward/core/git/CommitMsg.scala, 2468, 2468, 2538) -> MacroInfo(
[info]     expandedMacros = 1,
[info]     expandedNodes = 0,
[info]     expansionTime = 104 microseconds
[info]   ),
[info]   RangePosition(/scala-steward/modules/core/src/main/scala/org/scalasteward/core/buildtool/scalacli/ScalaCliAlg.scala, 3149, 3149, 3163) -> MacroInfo(
[info]     expandedMacros = 1,
[info]     expandedNodes = 0,
[info]     expansionTime = 298 microseconds
[info]   ),
[info]   source-/scala-steward/modules/core/src/main/scala/org/scalasteward/core/data/DependencyInfo.scala,line-29,offset=913 -> MacroInfo(
[info]     expandedMacros = 9,
[info]     expandedNodes = 26,
[info]     expansionTime = 182 microseconds
[info]   ),
[info]   source-/scala-steward/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala,line-247,offset=8335 -> MacroInfo(
[info]     expandedMacros = 10,
[info]     expandedNodes = 29,
[info]     expansionTime = 163 microseconds
[info]   ),
```
@DSlug It'd be nice if you could validate this.